### PR TITLE
Remove insertion of ZWJ and VS16 (#24)

### DIFF
--- a/layerize.js
+++ b/layerize.js
@@ -576,16 +576,6 @@ function processFile(fileName, data) {
             // simple character (single codepoint)
             chars.push({unicode: unicodes[0], components: layers});
         } else {
-            // Ligatures: Keycap sequences only apply when there's U+FE0F in between.
-            // Otherwise, if not a Regional-Indicator pair or Fitzpatrick-modified char,
-            // insert ZWJ between components
-            if (unicodes.length == 2 && parseInt(unicodes[1], 16) == 0x20e3) {
-                unicodes = unicodes.join(",fe0f,").split(",");
-            } else if (unicodes.length > 2 ||
-                !((parseInt(unicodes[0], 16) >= 0x1f1e6 && parseInt(unicodes[0], 16) <= 0x1f1ff) ||
-                  (parseInt(unicodes[1], 16) >= 0x1f3fb && parseInt(unicodes[1], 16) <= 0x1f3ff))) {
-                unicodes = unicodes.join(",200d,").split(",");
-            }
             ligatures.push({unicodes: unicodes, components: layers});
             // create the placeholder glyph for the ligature (to be mapped to a set of color layers)
             fs.writeFileSync(targetDir + "/glyphs/u" + unicodes.join("_") + ".svg",

--- a/tests/index.js
+++ b/tests/index.js
@@ -221,23 +221,7 @@ ComparisonTest.prototype = {
     var cpEnd = codePointsArray.length - 1;
 
     var svgUrl = this.svgUrl = '../build/colorGlyphs/u' +
-      this.codePoints.filter(function(cp) {
-        // Remove zero width joiner and VS16.
-        if (cp == prevCp && prevCp == beforePrevCp && cp == 0x200d) {
-          beforePrevCp = prevCp;
-          prevCp = cp;
-          return cp;
-        };
-        if (cp == 0xfe0f && cp !== codePointsArray[cpEnd]) {
-          beforePrevCp = prevCp;
-          prevCp = cp;
-          return cp !== 0xfe0f;
-        }
-        beforePrevCp = prevCp;
-        prevCp = cp;
-        return cp !== 0x200d;
-      })
-      .map(function(cp) {
+      this.codePoints.map(function(cp) {
         var str = cp.toString(16);
         return str;
       }).join('-') + '.svg';


### PR DESCRIPTION
File names of Twemoji assets come with the right ZWJs and VS16s; there is not need to insert or remove them in the code.